### PR TITLE
Narrow load_checkpoint exception handling to real corruption errors

### DIFF
--- a/train.py
+++ b/train.py
@@ -661,7 +661,7 @@ class Trainer:
         """
         try:
             ckpt = torch.load(checkpoint_path, map_location=self.device, weights_only=False)
-        except (RuntimeError, EOFError, Exception) as exc:
+        except (RuntimeError, EOFError, pickle.UnpicklingError) as exc:
             import warnings
             warnings.warn(
                 f"Checkpoint {checkpoint_path} is corrupted and will be "


### PR DESCRIPTION
## What

`Trainer.load_checkpoint()` wrapped `torch.load(...)` in `except (RuntimeError, EOFError, Exception)`. The bare `Exception` makes the other two entries redundant and catches every error, then warns that the checkpoint is "corrupted" and silently starts training from scratch.

## Why

The catch-all masks two different problems behind one misleading message:

- Unexpected errors (for example a checkpoint that references a class which no longer exists, raising `ModuleNotFoundError`) are swallowed instead of surfaced.
- A missing or mistyped `--resume` path raises `FileNotFoundError`, which was also caught, so a typo silently discarded the user's intent to resume and kicked off a fresh, potentially multi-hour, training run.

## How

Catch only the exceptions that genuinely indicate a corrupt or truncated checkpoint: `RuntimeError` (what torch's C++ zip reader raises on a bad archive), `EOFError`, and `pickle.UnpicklingError` (`pickle` is already imported). Everything else now propagates. This matches the narrow, specific exception handling already used by `_load_data_cache()` in the same file.

## Behavior change worth noting

`--resume <missing-or-unreadable-path>` now fails loudly with the underlying error instead of silently training from scratch. `load_state_dict()` is outside this `try` block and is unaffected, so a genuine shape or key mismatch still raises as before.

## Testing

`python -m py_compile train.py` passes.

AI assistance (Claude) was used to analyze the issue and prepare this change.
