### PR TITLE
Use haversine distance for nearest-neighbour environmental fill

### DIFF
--- a/utils/geoutils.py
+++ b/utils/geoutils.py
@@ -623,8 +623,20 @@ def fill_missing_with_nearest(gdf: gpd.GeoDataFrame, columns: Optional[List[str]
         for mi in missing_idx:
             if not rows_with_any[mi]:
                 continue
-            # squared distances to non-missing points
-            dists = np.sum((coords[non_missing_idx] - coords[mi]) ** 2, axis=1)
+            # Great-circle (haversine) distances to non-missing points.
+            # coords columns are [lon, lat] in degrees; a plain Euclidean
+            # distance on degrees is wrong on a sphere: it ignores the
+            # cos(latitude) scaling of longitude and treats the +/-180 deg
+            # antimeridian as maximally far apart, so it can pick a nearest
+            # neighbour on the opposite side of the globe.
+            lon0, lat0 = np.radians(coords[mi])
+            lons = np.radians(coords[non_missing_idx, 0])
+            lats = np.radians(coords[non_missing_idx, 1])
+            dlon = lons - lon0
+            dlat = lats - lat0
+            a = (np.sin(dlat / 2.0) ** 2
+                 + np.cos(lat0) * np.cos(lats) * np.sin(dlon / 2.0) ** 2)
+            dists = 2.0 * np.arcsin(np.sqrt(np.clip(a, 0.0, 1.0)))
             # indices of the k nearest non-missing points
             order = np.argsort(dists)[:k]
             nearest_idx = non_missing_idx[order]


### PR DESCRIPTION
## What

`fill_missing_with_nearest()` in `utils/geoutils.py` chose the k nearest cells to fill missing environmental values using squared Euclidean distance on raw `[lon, lat]` degree coordinates.

## Why

Euclidean distance on degrees is wrong on a sphere:

- It ignores the `cos(latitude)` scaling of longitude, so a degree of longitude is over-weighted away from the equator. At 60 degrees N a degree of longitude is about half the ground distance of a degree of latitude, so the old metric was biased toward east-west neighbours at mid and high latitudes.
- It treats the +/-180 degree antimeridian as maximally far apart, so a cell at lon +179.5 was considered about 359 degrees from a cell at lon -179.5 instead of about 1 degree.

As a result, a missing cell near the dateline could be filled from a cell on the opposite side of the globe. Example: a missing cell at (179.5, 0) was filled from (100, 0) at about 8840 km instead of (-179.5, 0) at about 111 km.

## How

Replace the Euclidean distance with the haversine great-circle distance. The computation stays vectorised over the non-missing cells and the surrounding `argsort` / k-nearest logic is unchanged; only the distance metric is corrected. The distances are used solely for relative ordering, so the constant earth-radius factor is omitted.

## Testing

`python -m py_compile utils/geoutils.py` passes. The metric was checked on an antimeridian example: the old Euclidean distance selected a neighbour about 8840 km away, while haversine correctly selects the one about 111 km away. For ordinary cells away from the dateline the selection is effectively unchanged.

AI assistance (Claude) was used to analyze the issue and prepare this change.
