### PR TITLE
Normalize h3_index in combine to prevent a silent empty join

### DIFF
--- a/utils/combine.py
+++ b/utils/combine.py
@@ -220,6 +220,14 @@ def combine_data(
     
     logging.info(f"Loading H3 environmental data from {h3_path}")
     h3_df = gpd.read_parquet(h3_path)
+    # Normalise h3_index to hex strings so it matches the string cell ids
+    # produced by h3.latlng_to_cell during GBIF processing. A parquet that
+    # stored h3_index as int64 would otherwise match nothing, silently
+    # producing an empty result. Mirrors the same guard in utils/data.py.
+    if 'h3_index' in h3_df.columns:
+        h3_df['h3_index'] = h3_df['h3_index'].apply(
+            lambda x: x if isinstance(x, str) else h3.int_to_str(x)
+        )
     valid_h3_cells = set(h3_df['h3_index'].values)
     logging.info(f"Loaded {len(valid_h3_cells)} valid H3 cells")
 


### PR DESCRIPTION
## What

`combine_geodata_with_gbif()` in `utils/combine.py` reads the environmental parquet and builds `valid_h3_cells` and `h3_to_idx` directly from its `h3_index` column, then matches them against the cell ids returned by `h3.latlng_to_cell(...)`, which are hex strings.

## Why

If the parquet stored `h3_index` as int64, the `isin` filter and the `h3_to_idx` dict lookup compare ints against hex strings and match nothing. Every GBIF cell is then counted as "missing", and the combined dataset is written with empty week lists, silently, with only a "Skipped N H3 cells" warning. The resolution auto-detect `h3.get_resolution(h3_df['h3_index'].iloc[0])` would also error on an int64 value.

`utils/data.py` already guards against this exact case, normalizing `h3_index` to hex strings on load (comment: "Ensure h3_index is consistent (hex strings)"). `combine.py` lacked the same guard, so the two readers disagreed on the key type.

## How

Normalize `h3_index` to hex strings right after reading the parquet, mirroring the guard in `utils/data.py`:

```python
if 'h3_index' in h3_df.columns:
    h3_df['h3_index'] = h3_df['h3_index'].apply(
        lambda x: x if isinstance(x, str) else h3.int_to_str(x)
    )
```

This fixes both downstream consumers (`valid_h3_cells` and `h3_to_idx`) and the resolution auto-detect. For the normal pipeline, where `geoutils` already writes string `h3_index`, it is a pure no-op passthrough. The NaN/None behavior is identical to the existing `data.py` guard (a valid cell-keyed parquet has no null indexes).

## Testing

`python -m py_compile utils/combine.py` passes. The logic is byte-identical to the proven normalization in `utils/data.py`. The h3 package was not installed in my environment, so the full combine run was not executed.

AI assistance (Claude) was used to analyze the issue and prepare this change.
