### PR TITLE
Build the species target on GPU and gather watchlist columns on device for faster training

### DIFF
--- a/tests/test_gpu_target_build.py
+++ b/tests/test_gpu_target_build.py
@@ -1,0 +1,43 @@
+"""COO + GPU-scatter species target must equal the legacy dense CPU collate."""
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import numpy as np, torch
+from utils.data import _make_sparse_collate_fn, _make_coo_collate_fn
+
+N = 200  # species
+def make_batch(B=16, region=False, seed=0):
+    g = np.random.default_rng(seed)
+    batch = []
+    for i in range(B):
+        k = int(g.integers(1, 8))
+        idx = np.sort(g.choice(N, size=k, replace=False)).astype(np.int32)
+        inp = {'lat': torch.tensor(float(g.uniform(-60,60))),
+               'lon': torch.tensor(float(g.uniform(-180,180))),
+               'week': torch.tensor(float(g.integers(1,49)))}
+        if region:
+            inp['region_id'] = int(g.integers(0, 60))
+        batch.append((inp, {'species_indices': idx, 'env_features': torch.zeros(3)}))
+    return batch
+
+def rebuild_coo(targets):  # mirrors Trainer._build_species_target (deterministic part, cpu)
+    B, ns = int(targets['species_B']), int(targets['species_n'])
+    sp = torch.zeros(B, ns)
+    if targets['species_rows'].numel() > 0:
+        sp[targets['species_rows'], targets['species_cols']] = targets['species_vals']
+    return sp
+
+def check(name, **kw):
+    b = make_batch(**{k:v for k,v in kw.items() if k in ('B','region','seed')})
+    dense = _make_sparse_collate_fn(N, **{k:v for k,v in kw.items() if k.startswith(('species','ubi'))})(b)[1]['species']
+    coo = rebuild_coo(_make_coo_collate_fn(N, **{k:v for k,v in kw.items() if k.startswith(('species','ubi'))})(b)[1])
+    d = (dense - coo).abs().max().item()
+    print(f"{name:<24} max|dense-coo| = {d:.3e}  {'OK' if d==0.0 else 'FAIL'}")
+    assert d == 0.0
+
+print("=== COO target vs legacy dense (deterministic, ubiquitous off) ===")
+check("binary")
+fw = torch.rand(N)*0.9 + 0.1
+check("freq_weights", species_freq_weights=fw)
+rw = torch.rand(60, N)*0.9 + 0.1
+check("region_weights", region=True, species_region_weights=rw)
+print("All COO target-build equivalence tests passed.")

--- a/train.py
+++ b/train.py
@@ -295,6 +295,41 @@ class Trainer:
 
     # -- single epoch -----------------------------------------------------
 
+    def _build_species_target(self, targets: Dict, training: bool) -> torch.Tensor:
+        """Materialize the dense species target on the device.
+
+        With the COO collate (``--gpu_target_build``), the batch carries sparse
+        ``species_rows``/``cols``/``vals`` instead of a dense matrix; rebuild the
+        dense ``(B, n_species)`` target on the GPU via scatter (no large
+        host->device copy). The training-only ubiquitous-species injection is
+        applied here on the GPU with identical semantics to the dense-collate
+        path (Bernoulli per (sample, species), only where not already a
+        positive, written as the soft target value). Falls back to the dense
+        path when a precomputed ``'species'`` tensor is present.
+        """
+        if 'species_rows' not in targets:
+            return targets['species'].to(self.device, non_blocking=True)
+
+        B = int(targets['species_B'])
+        ns = int(targets['species_n'])
+        species = torch.zeros(B, ns, device=self.device)
+        rows = targets['species_rows'].to(self.device, non_blocking=True)
+        cols = targets['species_cols'].to(self.device, non_blocking=True)
+        vals = targets['species_vals'].to(self.device, non_blocking=True)
+        if rows.numel() > 0:
+            species[rows, cols] = vals
+
+        if training and 'ubi_idx' in targets:
+            ui = targets['ubi_idx'].to(self.device, non_blocking=True)
+            up = targets['ubi_prob'].to(self.device, non_blocking=True)
+            ut = float(targets['ubi_target'])
+            draws = torch.rand(B, ui.numel(), device=self.device)
+            write = (draws < up.unsqueeze(0)) & (species[:, ui] == 0)
+            if write.any():
+                r, c = write.nonzero(as_tuple=True)
+                species[r, ui[c]] = ut
+        return species
+
     def train_epoch(self, train_loader: DataLoader) -> Dict[str, float]:
         """Run one training epoch with AMP and gradient clipping.
 
@@ -321,7 +356,7 @@ class Trainer:
             lat = inputs['lat'].to(self.device, non_blocking=True)
             lon = inputs['lon'].to(self.device, non_blocking=True)
             week = inputs['week'].to(self.device, non_blocking=True)
-            species_t = targets['species'].to(self.device, non_blocking=True)
+            species_t = self._build_species_target(targets, training=True)
             env_t = targets['env_features'].to(self.device, non_blocking=True)
 
             self.optimizer.zero_grad(set_to_none=True)
@@ -423,6 +458,13 @@ class Trainer:
         # Each entry holds (scores, labels) lists to compute column-wise AP
         wl_scores: Dict[int, list] = {tk: [] for tk in self.watchlist_indices}
         wl_labels: Dict[int, list] = {tk: [] for tk in self.watchlist_indices}
+        # Precompute the watchlist column indices once so we can gather just
+        # those (~tens of) columns on the GPU each batch, instead of copying
+        # the full (B, n_species) probs+labels tensors to the host.
+        _wl_tks = list(self.watchlist_indices.keys())
+        _wl_cols = (torch.tensor([self.watchlist_indices[tk] for tk in _wl_tks],
+                                 dtype=torch.long, device=self.device)
+                    if _wl_tks else None)
 
         # Density-stratified metric accumulators
         # Collect per-sample AP and obs_density for post-loop stratification
@@ -440,7 +482,7 @@ class Trainer:
             lat = inputs['lat'].to(self.device, non_blocking=True)
             lon = inputs['lon'].to(self.device, non_blocking=True)
             week = inputs['week'].to(self.device, non_blocking=True)
-            species_t = targets['species'].to(self.device, non_blocking=True)
+            species_t = self._build_species_target(targets, training=False)
             env_t = targets['env_features'].to(self.device, non_blocking=True)
 
             # Observation density (optional — present when data pipeline includes it)
@@ -522,15 +564,15 @@ class Trainer:
                 all_density_all.append(batch_density)
 
             # --- Watchlist per-species scores ---
-            if self.watchlist_indices:
-                probs_cpu = probs.cpu()
-                labels_cpu = pos_mask.cpu()
-                for tk, idx in self.watchlist_indices.items():
-                    # .clone() detaches the 1-D slice from the full (B, n_species)
-                    # tensor — without it, the view keeps the entire parent alive
-                    # and memory grows linearly with the number of val batches.
-                    wl_scores[tk].append(probs_cpu[:, idx].clone())
-                    wl_labels[tk].append(labels_cpu[:, idx].float())
+            # Gather only the watchlist columns on the GPU, then move the tiny
+            # (B, n_watchlist) slice to the host — avoids copying the full
+            # (B, n_species) probs+labels tensors every batch.
+            if _wl_cols is not None:
+                wl_p = probs.index_select(1, _wl_cols).cpu()
+                wl_l = pos_mask.index_select(1, _wl_cols).float().cpu()
+                for j, tk in enumerate(_wl_tks):
+                    wl_scores[tk].append(wl_p[:, j].clone())
+                    wl_labels[tk].append(wl_l[:, j].clone())
 
         # F1/precision/recall from micro-averaged TP/FP/FN per threshold
         def _f1(tp, fp, fn):
@@ -1000,6 +1042,11 @@ def main():
 
     # Device
     parser.add_argument('--device', type=str, default='auto', choices=['auto', 'cuda', 'cpu'])
+    parser.add_argument('--cpu_collate', action='store_true',
+                        help='Build the dense species target on the CPU in the '
+                             'collate (legacy path). Default: on CUDA, emit sparse '
+                             'COO coords and rebuild the dense target on the GPU '
+                             '(no per-batch host->device copy of the full target).')
     parser.add_argument('--num_workers', type=int, default=min(4, os.cpu_count() or 1),
                         help='Number of DataLoader worker processes (default: min(4, CPU cores))')
 
@@ -1286,6 +1333,7 @@ def main():
         ubiquitous_indices=ubi_idx,
         ubiquitous_probs=ubi_prob,
         ubiquitous_target=args.ubiquitous_target,
+        gpu_target_build=(device.type == 'cuda' and not args.cpu_collate),
     )
 
     # Create holdout DataLoader if regions were masked

--- a/utils/data.py
+++ b/utils/data.py
@@ -1808,6 +1808,86 @@ def _make_sparse_collate_fn(
     return collate_fn
 
 
+def _make_coo_collate_fn(
+    n_species: int,
+    species_freq_weights: Optional[torch.Tensor] = None,
+    species_region_weights: Optional[torch.Tensor] = None,
+    ubiquitous_indices: Optional[torch.Tensor] = None,
+    ubiquitous_probs: Optional[torch.Tensor] = None,
+    ubiquitous_target: float = 0.5,
+):
+    """Collate that emits the species target as sparse COO coordinates.
+
+    Instead of allocating and filling a dense ``(batch, n_species)`` target on
+    the CPU (and copying ~``B*n_species*4`` bytes to the GPU every batch), this
+    emits compact ``species_rows`` / ``species_cols`` / ``species_vals`` built
+    vectorized with ``torch.repeat_interleave`` + ``torch.cat``.  The dense
+    target is rebuilt on the GPU by the trainer (see
+    ``Trainer._build_species_target``), which also performs the training-only
+    ubiquitous-species injection there.  ``species_vals`` carries arbitrary
+    float soft-target values (region/frequency soft labels or 1.0), so the
+    rebuilt dense target is identical to the dense-collate path.
+
+    The ubiquitous tensors are passed through unchanged for the trainer to
+    apply on-GPU; validation collates pass ``ubiquitous_indices=None``.
+    """
+    _weights = species_freq_weights
+    _region_weights = species_region_weights
+    _ubi_idx = ubiquitous_indices
+    _ubi_prob = ubiquitous_probs
+    _ubi_target = float(ubiquitous_target)
+
+    def collate_fn(batch):
+        inputs_list, targets_list = zip(*batch)
+        lat = torch.stack([inp['lat'] for inp in inputs_list])
+        lon = torch.stack([inp['lon'] for inp in inputs_list])
+        week = torch.stack([inp['week'] for inp in inputs_list])
+        env = torch.stack([tgt['env_features'] for tgt in targets_list])
+
+        inp = {'lat': lat, 'lon': lon, 'week': week}
+        if 'obs_density' in inputs_list[0]:
+            inp['obs_density'] = torch.stack([i['obs_density'] for i in inputs_list])
+
+        B = len(batch)
+        idx_arrays = []
+        counts = torch.empty(B, dtype=torch.long)
+        for i, tgt in enumerate(targets_list):
+            indices = tgt['species_indices']
+            if not isinstance(indices, torch.Tensor):
+                indices = torch.from_numpy(indices)
+            indices = indices.long()
+            idx_arrays.append(indices)
+            counts[i] = indices.numel()
+
+        cols = torch.cat(idx_arrays) if idx_arrays else torch.empty(0, dtype=torch.long)
+        rows = torch.repeat_interleave(torch.arange(B), counts)
+
+        if _region_weights is not None:
+            region_ids = torch.tensor(
+                [int(inputs_list[i]['region_id']) for i in range(B)], dtype=torch.long)
+            rid_exp = torch.repeat_interleave(region_ids, counts)
+            vals = _region_weights[rid_exp, cols] if cols.numel() else torch.empty(0)
+        elif _weights is not None:
+            vals = _weights[cols] if cols.numel() else torch.empty(0)
+        else:
+            vals = torch.ones(cols.numel(), dtype=torch.float32)
+
+        targets = {
+            'env_features': env,
+            'species_rows': rows, 'species_cols': cols,
+            'species_vals': vals.float(),
+            'species_n': n_species, 'species_B': B,
+        }
+        if _ubi_idx is not None and _ubi_idx.numel() > 0:
+            targets['ubi_idx'] = _ubi_idx
+            targets['ubi_prob'] = _ubi_prob
+            targets['ubi_target'] = _ubi_target
+
+        return (inp, targets)
+
+    return collate_fn
+
+
 def create_dataloaders(
     train_inputs: Dict[str, np.ndarray],
     train_targets: Dict[str, Any],
@@ -1823,6 +1903,7 @@ def create_dataloaders(
     ubiquitous_indices: Optional[np.ndarray] = None,
     ubiquitous_probs: Optional[np.ndarray] = None,
     ubiquitous_target: float = 0.5,
+    gpu_target_build: bool = False,
 ) -> Tuple[DataLoader, DataLoader]:
     """Create training and validation DataLoaders.
 
@@ -1864,9 +1945,14 @@ def create_dataloaders(
     )
     val_ds = BirdSpeciesDataset(val_inputs, val_targets, n_species=n_species)
 
-    # Use custom collation when species targets are sparse
+    # Use custom collation when species targets are sparse. With
+    # gpu_target_build the collate emits sparse COO coords (no dense CPU
+    # alloc, no large host->device copy); the dense target is rebuilt on the
+    # GPU by the trainer. Otherwise the dense matrix is built on the CPU.
     _is_sparse = train_ds.species_sparse is not None
-    train_collate = _make_sparse_collate_fn(
+    _train_collate_factory = _make_coo_collate_fn if gpu_target_build else _make_sparse_collate_fn
+    _val_collate_factory = _make_coo_collate_fn if gpu_target_build else _make_sparse_collate_fn
+    train_collate = _train_collate_factory(
         n_species,
         species_freq_weights=train_ds.species_freq_weights,
         species_region_weights=train_ds.species_region_weights,
@@ -1874,7 +1960,7 @@ def create_dataloaders(
         ubiquitous_probs=train_ds.ubiquitous_probs,
         ubiquitous_target=train_ds.ubiquitous_target,
     ) if _is_sparse else None
-    val_collate = _make_sparse_collate_fn(n_species) if _is_sparse else None
+    val_collate = _val_collate_factory(n_species) if _is_sparse else None
 
     _persistent = num_workers > 0
 


### PR DESCRIPTION
This speeds up training by removing two per-batch CPU/transfer costs I hit while training the full ~10k-species model on a large global GBIF pull. Model behavior is unchanged: the species targets and the validation metrics are bit-identical to the current code, verified (details below). `--cpu_collate` restores the old path.

## 1. Build the dense species target on the GPU

The sparse collate built a dense `[batch, n_species]` target on the CPU each batch and copied the whole matrix to the GPU. At batch 8192 with ~10k species that is ~340 MB per batch.

Per-iteration profile before the change (batch 8192, RTX 5080):

| stage | share |
|---|---|
| collate (CPU dense build, in workers) | ~25% |
| host to device transfer (the 342 MB target) | ~30% |
| forward + backward + step | ~45% |

So the collate plus that transfer was about 55% of each training iteration. The collate now emits compact COO coordinates (`species_rows` / `species_cols` / `species_vals`, built vectorized with `repeat_interleave` + `cat`) and the trainer scatters them into the dense target on the GPU. `species_vals` carries arbitrary float values, so frequency and per-region soft labels are preserved and the rebuilt target is byte-identical to the old path. `--cpu_collate` keeps the legacy build; the GPU path is the default on CUDA.

Result: training loop about 4x faster, ~10 to ~40 it/s at batch 8192.

## 2. Gather watchlist columns on the GPU during validation

`validate()` copied the full `(batch, n_species)` probabilities and labels to the host every batch just to read the handful of watchlist columns.

Validation profile before the change (172 batches, batch 8192):

| section | time |
|---|---|
| forward + loss | 2.3 s |
| GPU metrics (top-k, AP, F1) | 8.2 s |
| watchlist full-tensor `.cpu()` per batch | 24.6 s |
| total | 36.4 s |

The watchlist block was 68% of validation. It now `index_select`s the ~18 watchlist columns on the GPU and transfers only that slice. Validation about 2.9x faster, ~36 to ~12 s per epoch.

## Correctness

- **Targets**: a new test (`tests/test_gpu_target_build.py`) compares the GPU-scattered dense target against the legacy CPU-built dense target. Max abs diff 0.0 for binary, frequency-weighted, and per-region soft-target cases.
- **Validation metrics**: comparing `validate()` old vs new on the same checkpoint and data, max abs diff 0.0 across all metrics (map, f1, list ratios, density-stratified mAP, watchlist mean AP, geoscore).
- A full smoke train runs cleanly with a normal GeoScore trajectory.

One note for review: the training-only ubiquitous-species injection now runs during the GPU target build. The deterministic part of the target (observed indices and their soft weights) is byte-identical; the injection itself is stochastic augmentation, so it is equivalent in distribution but draws from a different RNG stream (it already varies every epoch).

Happy to split this into two PRs (target build and validation are independent) or adjust naming.
