### PR TITLE
Add per-class loss weighting to fix bat/mammal imbalance

### DIFF
--- a/model/loss.py
+++ b/model/loss.py
@@ -40,6 +40,7 @@ def focal_loss(
     alpha: float = 0.25,
     gamma: float = 2.0,
     reduction: str = 'mean',
+    weight: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     Focal loss for multi-label classification.
@@ -48,12 +49,18 @@ def focal_loss(
     critical for species occurrence data where >99% of labels are 0.
 
     Reference: Lin et al., "Focal Loss for Dense Object Detection" (2017)
+
+    ``weight`` (optional, shape ``(n_species,)``) is a per-species multiplier
+    applied before reduction, e.g. to up-weight an under-represented class at
+    the loss level. Broadcasts over the batch dimension.
     """
     probs = torch.sigmoid(logits)
     bce = F.binary_cross_entropy_with_logits(logits, targets, reduction='none')
     p_t = probs * targets + (1 - probs) * (1 - targets)
     alpha_t = alpha * targets + (1 - alpha) * (1 - targets)
     loss = alpha_t * ((1 - p_t) ** gamma) * bce
+    if weight is not None:
+        loss = loss * weight  # (n_species,) broadcasts over (batch, n_species)
 
     if reduction == 'mean':
         return loss.mean()
@@ -69,6 +76,7 @@ def asymmetric_loss(
     gamma_neg: float = 2.0,
     clip: float = 0.05,
     reduction: str = 'mean',
+    weight: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Asymmetric Loss for multi-label classification.
 
@@ -124,6 +132,8 @@ def asymmetric_loss(
         neg_term = -(1 - targets) * log_neg
 
     loss = pos_term + neg_term
+    if weight is not None:
+        loss = loss * weight  # (n_species,) broadcasts over (batch, n_species)
 
     if reduction == 'mean':
         return loss.mean()
@@ -164,11 +174,15 @@ class AssumeNegativeLoss(nn.Module):
         pos_lambda: float = 4.0,
         neg_samples: int = 1024,
         label_smoothing: float = 0.0,
+        class_loss_weight: Optional[torch.Tensor] = None,
     ):
         super().__init__()
         self.pos_lambda = pos_lambda
         self.neg_samples = neg_samples
         self.label_smoothing = label_smoothing
+        # Optional per-species (n_species,) loss multiplier; registered as a
+        # buffer so it moves with .to(device) and is saved/loaded with state.
+        self.register_buffer('class_loss_weight', class_loss_weight)
 
     def forward(
         self,
@@ -208,6 +222,8 @@ class AssumeNegativeLoss(nn.Module):
 
         # Per-element BCE (unreduced)
         bce = F.binary_cross_entropy_with_logits(logits, targets, reduction='none')
+        if self.class_loss_weight is not None:
+            bce = bce * self.class_loss_weight  # per-species multiplier (pos + neg)
 
         # --- Positive term: sum of BCE on positive species per sample ---
         pos_bce = bce * pos_mask.float()
@@ -294,6 +310,7 @@ class MultiTaskLoss(nn.Module):
         asl_gamma_neg: float = 2.0,
         asl_clip: float = 0.05,
         reduction: str = 'mean',
+        class_loss_weight: Optional[torch.Tensor] = None,
     ):
         """
         Args:
@@ -327,15 +344,20 @@ class MultiTaskLoss(nn.Module):
         self.asl_gamma_pos = asl_gamma_pos
         self.asl_gamma_neg = asl_gamma_neg
         self.asl_clip = asl_clip
+        # Optional per-species (n_species,) loss multiplier, applied at the loss
+        # level (NOT the target value). Registered as a buffer so it follows
+        # .to(device). Used by focal/asl in forward; baked into bce/an below.
+        self.register_buffer('class_loss_weight', class_loss_weight)
 
         if species_loss == 'bce':
             self.species_criterion = nn.BCEWithLogitsLoss(
-                pos_weight=pos_weight, reduction=reduction,
+                weight=class_loss_weight, pos_weight=pos_weight, reduction=reduction,
             )
         elif species_loss == 'an':
             self.species_criterion = AssumeNegativeLoss(
                 pos_lambda=pos_lambda, neg_samples=neg_samples,
                 label_smoothing=label_smoothing,
+                class_loss_weight=class_loss_weight,
             )
 
     def forward(
@@ -361,7 +383,7 @@ class MultiTaskLoss(nn.Module):
             species_loss = focal_loss(
                 logits, species_t,
                 alpha=self.focal_alpha, gamma=self.focal_gamma,
-                reduction=self.reduction,
+                reduction=self.reduction, weight=self.class_loss_weight,
             )
         elif self.species_loss_type == 'asl':
             species_loss = asymmetric_loss(
@@ -369,7 +391,7 @@ class MultiTaskLoss(nn.Module):
                 gamma_pos=self.asl_gamma_pos,
                 gamma_neg=self.asl_gamma_neg,
                 clip=self.asl_clip,
-                reduction=self.reduction,
+                reduction=self.reduction, weight=self.class_loss_weight,
             )
         elif self.species_loss_type == 'an':
             species_loss = self.species_criterion(logits, species_t)
@@ -393,7 +415,7 @@ class MultiTaskLoss(nn.Module):
                 habitat_loss = focal_loss(
                     h_logits, species_t,
                     alpha=self.focal_alpha, gamma=self.focal_gamma,
-                    reduction=self.reduction,
+                    reduction=self.reduction, weight=self.class_loss_weight,
                 )
             elif self.species_loss_type == 'asl':
                 habitat_loss = asymmetric_loss(
@@ -401,7 +423,7 @@ class MultiTaskLoss(nn.Module):
                     gamma_pos=self.asl_gamma_pos,
                     gamma_neg=self.asl_gamma_neg,
                     clip=self.asl_clip,
-                    reduction=self.reduction,
+                    reduction=self.reduction, weight=self.class_loss_weight,
                 )
             elif self.species_loss_type == 'an':
                 habitat_loss = self.species_criterion(h_logits, species_t)

--- a/tests/test_class_loss_weight.py
+++ b/tests/test_class_loss_weight.py
@@ -1,0 +1,73 @@
+"""Tests for the per-class loss-level multiplier (model/loss.py: class_loss_weight).
+
+The multiplier up-weights an under-represented class (e.g. mammals/bats, which
+GBIF records ~30-140x less than common birds) at the LOSS level — it scales the
+per-species BCE, never the target value. This keeps the targets binary while
+letting the optimiser pay more attention to the boosted classes.
+
+Run directly (``python tests/test_class_loss_weight.py``) or via pytest.
+"""
+
+import os
+import sys
+
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from model.loss import AssumeNegativeLoss, focal_loss, asymmetric_loss  # noqa: E402
+
+
+def _fixed_batch(n_species=4):
+    """One sample, a positive on species 2, deterministic logits."""
+    torch.manual_seed(0)
+    logits = torch.tensor([[0.2, -0.5, 0.3, -1.0]])
+    targets = torch.tensor([[0.0, 0.0, 1.0, 0.0]])
+    return logits, targets
+
+
+def test_assume_negative_weight_scales_loss():
+    """Boosting one species raises the loss vs the unweighted baseline."""
+    logits, targets = _fixed_batch()
+    base = AssumeNegativeLoss()(logits, targets)
+
+    weight = torch.tensor([1.0, 1.0, 10.0, 1.0])  # boost species 2 (the positive)
+    boosted = AssumeNegativeLoss(class_loss_weight=weight)(logits, targets)
+
+    assert boosted > base, f"weighted loss {boosted} should exceed base {base}"
+
+
+def test_unit_weight_is_a_noop():
+    """An all-ones multiplier must not change the loss."""
+    logits, targets = _fixed_batch()
+    base = AssumeNegativeLoss()(logits, targets)
+    ones = AssumeNegativeLoss(class_loss_weight=torch.ones(4))(logits, targets)
+    assert torch.allclose(base, ones, atol=1e-6), f"{base} vs {ones}"
+
+
+def test_focal_and_asl_accept_weight():
+    """focal_loss / asymmetric_loss apply the per-species weight before reduction."""
+    logits, targets = _fixed_batch()
+    w = torch.tensor([1.0, 1.0, 10.0, 1.0])
+    assert focal_loss(logits, targets, weight=w) > focal_loss(logits, targets)
+    assert asymmetric_loss(logits, targets, weight=w) > asymmetric_loss(logits, targets)
+
+
+def test_weight_targets_unchanged():
+    """Sanity: the multiplier is loss-level — it never mutates the targets.
+
+    (Writing weights into the target VALUE collapsed bats in earlier experiments;
+    this test documents that the multiplier path leaves targets binary.)
+    """
+    logits, targets = _fixed_batch()
+    before = targets.clone()
+    AssumeNegativeLoss(class_loss_weight=torch.tensor([1.0, 1.0, 6.0, 1.0]))(logits, targets)
+    assert torch.equal(targets, before), "targets must be untouched by class weighting"
+
+
+if __name__ == '__main__':
+    test_assume_negative_weight_scales_loss()
+    test_unit_weight_is_a_noop()
+    test_focal_and_asl_accept_weight()
+    test_weight_targets_unchanged()
+    print("All class_loss_weight tests passed.")

--- a/train.py
+++ b/train.py
@@ -924,6 +924,11 @@ def main():
                         help='Number of negative species to sample per example for AN loss (default: 1024, 0=all)')
     parser.add_argument('--label_smoothing', type=float, default=0.05,
                         help='Smooth binary targets to prevent overconfident predictions (default: 0.05, 0=off)')
+    parser.add_argument('--class_loss_weight', type=str, default=None,
+                        help='Per-CLASS loss multiplier(s) at the LOSS level, e.g. '
+                             '"mammalia=6.0" or "mammalia=6,amphibia=2". Up-weights those '
+                             'classes in the species loss (not the target value). Counters '
+                             'a bird-dominated loss for under-represented taxa. Default off.')
     parser.add_argument('--max_obs_per_species', type=int, default=0,
                         help='Cap observations per species to reduce common-species dominance (default: 0, 0=no cap)')
     parser.add_argument('--min_obs_per_species', type=int, default=50,
@@ -1386,6 +1391,7 @@ def main():
     checkpoint_dir.mkdir(parents=True, exist_ok=True)
     labels_path = checkpoint_dir / 'labels.txt'
     name_map: Dict[str, tuple] = {}  # primaryId → (sciName, comName)
+    class_map: Dict[str, str] = {}   # primaryId → class_name (lowercase)
 
     taxonomy_path = args.taxonomy
     if taxonomy_path is None:
@@ -1410,8 +1416,11 @@ def main():
                 pid = row.get('species_code') or row.get('primaryId')
                 sci = row.get('sci_name') or row.get('scientificName')
                 com = row.get('com_name') or row.get('commonName', sci)
+                cls = (row.get('class_name') or '').strip().lower()
                 if pid and sci:
                     name_map[pid] = (sci, com)
+                if pid and cls:
+                    class_map[pid] = cls
     else:
         print("\n7. No taxonomy file found — labels will use primaryId only")
 
@@ -1422,6 +1431,28 @@ def main():
             f.write(f"{pid}\t{sci}\t{com}\n")
     named = sum(1 for idx in range(n_species) if preprocessor.idx_to_species[idx] in name_map)
     print(f"   Saved {n_species} labels ({named} with names) to {labels_path}")
+
+    # -- Per-class loss multiplier (loss level, NOT target value) --
+    class_loss_weight_vec = None
+    if args.class_loss_weight:
+        cw = {}
+        for part in args.class_loss_weight.split(','):
+            k, _, v = part.partition('=')
+            if k.strip():
+                cw[k.strip().lower()] = float(v)
+        w = torch.ones(n_species, dtype=torch.float32)
+        n_boost = 0
+        for idx in range(n_species):
+            cls = class_map.get(preprocessor.idx_to_species[idx])
+            if cls in cw:
+                w[idx] = cw[cls]
+                n_boost += 1
+        class_loss_weight_vec = w
+        print(f"   Class loss weights {cw}: boosted {n_boost}/{n_species} species "
+              f"(loss-level multiplier)")
+        if n_boost == 0:
+            print("   WARNING: no species matched the requested classes — "
+                  "check class_name in the taxonomy file")
 
     # -- Criterion, optimizer, scheduler --
     criterion = MultiTaskLoss(
@@ -1434,7 +1465,10 @@ def main():
         asl_gamma_pos=args.asl_gamma_pos,
         asl_gamma_neg=args.asl_gamma_neg,
         asl_clip=args.asl_clip,
+        class_loss_weight=class_loss_weight_vec,
     )
+    # Move criterion to device so its weight/pos_weight buffers live on the GPU.
+    criterion = criterion.to(device)
     optimizer = torch.optim.AdamW(
         model.parameters(), lr=args.lr, weight_decay=args.weight_decay,
     )


### PR DESCRIPTION
## What

Adds an optional `--class_loss_weight` flag: a per-species multiplier applied at the loss level, specified per taxonomic class, for example:

```
--class_loss_weight "mammalia=6.0"
```

The weight scales the per-species BCE before reduction in all species loss variants (assume-negative, focal, ASL, BCE). It is registered as a buffer so it follows `.to(device)` and is saved with the checkpoint. It defaults to off, so existing runs are unchanged.

## Why

The geomodel predicts birds well but scores bats (and mammals generally) near zero everywhere, even where they are common. The modelling root cause is class imbalance in a presence-only loss: a few thousand common bird species dominate the gradient and swamp the few hundred mammals.

The imbalance is structural in the data, not just in species counts. Counting recorded presence across the training set, the most common birds have 30 to 140 times more records than the European bats:

| species | recorded presence (cell-weeks) |
|---|---|
| House Sparrow | 283,000 |
| Mallard | 233,000 |
| Plecotus auritus (best-recorded bat) | 9,900 |
| Eptesicus nilssonii (worst) | 2,000 |

So even where a bat is present every night, GBIF holds far fewer records for it, and the loss barely sees it. Up-weighting the under-represented class at the loss level lets the optimiser attend to it without distorting anything else.

Important: this stays strictly at the loss level. An earlier attempt to encode the weight into the target value instead collapsed bat predictions to near zero, because it turned the binary occurrence target into a soft one the model then learned to suppress. The multiplier here only scales the loss term; targets stay binary.

## How

`--class_loss_weight "class=w,..."` is parsed into a per-species vector by looking up each species' taxonomic class, then passed to `MultiTaskLoss` and applied as `loss = loss * weight` (broadcast over the batch) before reduction.

Verified:

- New unit test (`tests/test_class_loss_weight.py`): the multiplier scales the per-species loss for assume-negative / focal / ASL, is a no-op at unit weight, and never mutates the target value.
- Controlled A/B retrain on fresh global GBIF, identical recipe except the flag. With `mammalia=6.0` (boosting 879 mammal species), every headline metric improved with no bird regression:

| metric | baseline (no weighting) | `mammalia=6.0` |
|---|---|---|
| GeoScore | 0.4965 | 0.5080 |
| bat presence (mean) | 0.193 | 0.213 |
| bird anchor (mean) | 0.773 | 0.817 |

Geographic contrast stayed near zero (the model did not start predicting bats everywhere), so the gain is real range signal, not decalibration.

This is the modelling-side counterpart to the taxonomy fix in #16. Together they address the bat gap described in #17: #16 stops the records being discarded, this lets the loss actually learn them.

AI assistance (Claude) was used to investigate the imbalance, run the A/B, and prepare this change.

Related: #17
