### PR TITLE
Add spatial-block validation split to reduce autocorrelation leakage

### DIFF
--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -1,0 +1,148 @@
+"""Tests for the train/val split logic (utils/data.py: H3DataPreprocessor.split_data).
+
+Focus: the spatial-block split mode. A random or exact-coordinate split leaks via
+spatial autocorrelation — two distinct points a few km apart can land on opposite
+sides of the split, so the model half-sees the validation answer and GeoScore is
+inflated. ``split_mode='block'`` assigns whole coarse H3 cells (geographic blocks)
+to either train or val, so no validation block touches a training block.
+
+Run directly (``python tests/test_split.py``) or via pytest.
+"""
+
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import h3  # noqa: E402
+
+from utils.data import H3DataPreprocessor  # noqa: E402
+
+
+# A handful of cluster centres spread across the globe.  Each becomes one coarse
+# H3 block; we scatter several jittered points inside each so that an exact-
+# coordinate split would be tempted to split a block across train and val.
+_CLUSTER_CENTRES = [
+    (60.17, 24.94),   # Helsinki
+    (52.52, 13.40),   # Berlin
+    (48.85, 2.35),    # Paris
+    (41.90, 12.50),   # Rome
+    (40.42, -3.70),   # Madrid
+    (55.75, 37.62),   # Moscow
+    (51.51, -0.13),   # London
+    (59.33, 18.07),   # Stockholm
+    (47.50, 19.04),   # Budapest
+    (50.08, 14.44),   # Prague
+]
+
+
+def _make_clustered_inputs(points_per_cluster=20, jitter_deg=0.05, seed=0):
+    """Build synthetic inputs: several jittered points around each cluster centre.
+
+    jitter is small (a few km) so all points in a cluster share one coarse H3 cell.
+    Each sample carries a unique ``id`` so we can verify input/target alignment.
+    """
+    rng = np.random.default_rng(seed)
+    lats, lons = [], []
+    for clat, clon in _CLUSTER_CENTRES:
+        for _ in range(points_per_cluster):
+            lats.append(clat + rng.uniform(-jitter_deg, jitter_deg))
+            lons.append(clon + rng.uniform(-jitter_deg, jitter_deg))
+    lat = np.array(lats, dtype=np.float64)
+    lon = np.array(lons, dtype=np.float64)
+    ids = np.arange(len(lat))
+    inputs = {'lat': lat, 'lon': lon, 'id': ids}
+    targets = {'species_idx': ids.copy()}
+    return inputs, targets
+
+
+def _blocks(lat, lon, res):
+    return np.array([h3.latlng_to_cell(float(la), float(lo), res)
+                     for la, lo in zip(lat.tolist(), lon.tolist())])
+
+
+def test_block_split_blocks_are_disjoint():
+    """No validation sample may share an H3 block with any training sample."""
+    pre = H3DataPreprocessor()
+    inputs, targets = _make_clustered_inputs()
+    res = 3
+
+    tr_in, val_in, tr_tgt, val_tgt = pre.split_data(
+        inputs, targets, val_size=0.3, random_state=42,
+        split_mode='block', block_h3_res=res,
+    )
+
+    assert len(tr_in['lat']) > 0 and len(val_in['lat']) > 0, "both sides non-empty"
+
+    train_blocks = set(_blocks(tr_in['lat'], tr_in['lon'], res).tolist())
+    val_blocks = set(_blocks(val_in['lat'], val_in['lon'], res).tolist())
+    assert train_blocks.isdisjoint(val_blocks), (
+        f"train/val share blocks: {train_blocks & val_blocks}")
+
+
+def test_block_split_keeps_inputs_and_targets_aligned():
+    """Masking must apply identically to inputs and targets."""
+    pre = H3DataPreprocessor()
+    inputs, targets = _make_clustered_inputs()
+
+    tr_in, val_in, tr_tgt, val_tgt = pre.split_data(
+        inputs, targets, val_size=0.3, random_state=42,
+        split_mode='block', block_h3_res=3,
+    )
+
+    # Each sample's id was copied into both inputs['id'] and targets['species_idx'].
+    np.testing.assert_array_equal(tr_in['id'], tr_tgt['species_idx'])
+    np.testing.assert_array_equal(val_in['id'], val_tgt['species_idx'])
+    # Partition is complete and non-overlapping.
+    assert set(tr_in['id'].tolist()).isdisjoint(val_in['id'].tolist())
+    assert len(tr_in['id']) + len(val_in['id']) == len(inputs['id'])
+
+
+def test_block_mode_fixes_the_leak_that_location_mode_allows():
+    """The reason block mode exists: on clustered data, an exact-coordinate split
+    scatters a cluster's distinct points across train and val (same block on both
+    sides = leak), while the block split keeps each block on one side only."""
+    pre = H3DataPreprocessor()
+    inputs, targets = _make_clustered_inputs()
+    res = 3
+
+    # Location mode: distinct jittered coords let a block straddle the split.
+    _, loc_val, _, _ = pre.split_data(
+        dict(inputs), dict(targets), val_size=0.3, random_state=42,
+        split_mode='location',
+    )
+    loc_tr_blocks = set(_blocks(inputs['lat'], inputs['lon'], res).tolist())
+    loc_val_blocks = set(_blocks(loc_val['lat'], loc_val['lon'], res).tolist())
+    assert loc_val_blocks & loc_tr_blocks, \
+        "expected location mode to leak blocks across the split on this data"
+
+    # Block mode: no shared blocks (already asserted strictly in the disjoint test).
+    tr_in, val_in, _, _ = pre.split_data(
+        dict(inputs), dict(targets), val_size=0.3, random_state=42,
+        split_mode='block', block_h3_res=res,
+    )
+    blk_tr = set(_blocks(tr_in['lat'], tr_in['lon'], res).tolist())
+    blk_val = set(_blocks(val_in['lat'], val_in['lon'], res).tolist())
+    assert blk_tr.isdisjoint(blk_val)
+
+
+def test_location_mode_still_works():
+    """Back-compat: split_by_location=True keeps exact-coordinate grouping."""
+    pre = H3DataPreprocessor()
+    inputs, targets = _make_clustered_inputs(points_per_cluster=5)
+
+    tr_in, val_in, _, _ = pre.split_data(
+        inputs, targets, val_size=0.3, random_state=0,
+        split_by_location=True,
+    )
+    assert len(tr_in['lat']) > 0 and len(val_in['lat']) > 0
+
+
+if __name__ == '__main__':
+    test_block_split_blocks_are_disjoint()
+    test_block_split_keeps_inputs_and_targets_aligned()
+    test_block_mode_fixes_the_leak_that_location_mode_allows()
+    test_location_mode_still_works()
+    print("All split tests passed.")

--- a/train.py
+++ b/train.py
@@ -60,6 +60,7 @@ _DATA_CACHE_KEYS = [
     'propagate_env_dist_max', 'propagate_range_cap', 'smooth_gaps',
     'max_obs_per_species', 'min_obs_per_species', 'max_species',
     'val_size', 'sample_fraction',
+    'val_split_mode', 'block_h3_res',
     'holdout_regions',
     'label_freq_weight', 'label_freq_weight_min',
     'label_freq_weight_pct_lo', 'label_freq_weight_pct_hi',
@@ -1018,6 +1019,16 @@ def main():
 
     # Data split
     parser.add_argument('--val_size', type=float, default=0.1)
+    parser.add_argument('--val_split_mode', choices=['random', 'location', 'block'],
+                        default='location',
+                        help="Train/val split strategy. 'location' (default) keeps an "
+                             "identical coordinate on one side; 'block' holds out whole "
+                             "coarse H3 cells so no validation block touches a training "
+                             "block (honest spatial-generalisation estimate, less "
+                             "inflated GeoScore); 'random' is per-sample (leaky).")
+    parser.add_argument('--block_h3_res', type=int, default=3,
+                        help='H3 resolution for --val_split_mode block (default 3, '
+                             '~120 km across; lower = larger, more separated blocks).')
     parser.add_argument('--sample_fraction', type=float, default=1.0,
                         help='Fraction of locations to keep (default: 1.0 = all, 0.1 = 10%% random subset, subsampled once)')
 
@@ -1254,7 +1265,8 @@ def main():
         print("4. Splitting data...")
         train_in, val_in, train_tgt, val_tgt = preprocessor.split_data(
             inputs, targets, val_size=args.val_size,
-            random_state=42, split_by_location=True,
+            random_state=42, split_mode=args.val_split_mode,
+            block_h3_res=args.block_h3_res,
         )
         print(f"   Train: {len(train_in['lat']):,}  |  Val: {len(val_in['lat']):,}")
 

--- a/utils/data.py
+++ b/utils/data.py
@@ -1445,12 +1445,27 @@ class H3DataPreprocessor:
         targets: Dict[str, Any],
         val_size: float = 0.1,
         random_state: int = 42,
-        split_by_location: bool = True,
+        split_mode: str = 'location',
+        block_h3_res: int = 3,
+        split_by_location: Optional[bool] = None,
         **kwargs,
     ) -> Tuple:
-        """Split into train/val (optionally grouped by location to prevent leakage).
+        """Split into train/val, grouping to control spatial leakage.
 
-        Handles both dense ndarray and sparse list-of-arrays species targets.
+        ``split_mode``:
+          - ``'random'``: independent per-sample split (leaks via spatial
+            autocorrelation; inflates validation scores).
+          - ``'location'``: group by exact coordinate so an identical point
+            cannot straddle the split (default; still leaks between nearby
+            distinct points).
+          - ``'block'``: group by a coarse H3 cell (``block_h3_res``) so whole
+            geographic blocks go to either train or val and no validation block
+            touches a training block. Honest spatial-generalisation estimate.
+
+        ``split_by_location`` is the legacy boolean; when given it maps to
+        ``'location'`` (True) / ``'random'`` (False) and overrides ``split_mode``.
+
+        Handles both dense ndarray and sparse packed species targets.
 
         Returns:
             (train_inputs, val_inputs, train_targets, val_targets)
@@ -1458,24 +1473,41 @@ class H3DataPreprocessor:
         # Accept (and ignore) legacy test_size kwarg for backward compat
         _ = kwargs.pop('test_size', None)
 
+        # Legacy boolean takes precedence so existing callers keep their behaviour.
+        if split_by_location is not None:
+            split_mode = 'location' if split_by_location else 'random'
+
         n_samples = len(inputs['lat'])
         indices = np.arange(n_samples)
 
-        if split_by_location:
-            coord_tuples = list(zip(inputs['lat'].tolist(), inputs['lon'].tolist()))
-            unique_map: Dict[tuple, int] = {}
-            loc_ids = np.array([unique_map.setdefault(c, len(unique_map)) for c in coord_tuples])
-            unique_locs = np.unique(loc_ids)
+        if split_mode in ('location', 'block'):
+            if split_mode == 'block':
+                lats = inputs['lat'].tolist()
+                lons = inputs['lon'].tolist()
+                group_keys = [h3.latlng_to_cell(float(la), float(lo), block_h3_res)
+                              for la, lo in zip(lats, lons)]
+            else:  # 'location'
+                group_keys = list(zip(inputs['lat'].tolist(), inputs['lon'].tolist()))
 
-            locs_train, locs_val = train_test_split(
-                unique_locs, test_size=val_size, random_state=random_state
+            # Map each distinct group key to a small integer id for fast np.isin.
+            unique_map: Dict[Any, int] = {}
+            group_ids = np.array([unique_map.setdefault(k, len(unique_map))
+                                  for k in group_keys])
+            unique_groups = np.unique(group_ids)
+
+            groups_train, groups_val = train_test_split(
+                unique_groups, test_size=val_size, random_state=random_state
             )
-            train_mask = np.isin(loc_ids, locs_train)
-            val_mask = np.isin(loc_ids, locs_val)
-        else:
+            train_mask = np.isin(group_ids, groups_train)
+            val_mask = np.isin(group_ids, groups_val)
+        elif split_mode == 'random':
             idx_train, idx_val = train_test_split(indices, test_size=val_size, random_state=random_state)
             train_mask = np.isin(indices, idx_train)
             val_mask = np.isin(indices, idx_val)
+        else:
+            raise ValueError(
+                f"unknown split_mode {split_mode!r}; expected "
+                "'random', 'location', or 'block'")
 
         def _split_dict(d: Dict[str, Any], mask: np.ndarray) -> Dict[str, Any]:
             out = {}


### PR DESCRIPTION
## What

Adds a `--val_split_mode {random,location,block}` flag (plus `--block_h3_res`, default 3) controlling how the train/val split is formed:

- `random`: independent per-sample split.
- `location` (default, unchanged behaviour): groups by exact coordinate, so an identical point cannot land on both sides.
- `block`: groups by a coarse H3 cell (`--block_h3_res`) and assigns whole geographic blocks to either train or val.

Default stays `location`, so existing runs are unchanged. This is opt-in.

## Why

The current `location` split stops an identical coordinate from appearing in both train and val, but it does nothing about spatial autocorrelation between nearby distinct points. Two records a few km apart can still fall on opposite sides of the split. Species occurrence is spatially sticky, so the model effectively half-sees the validation answer from an adjacent training point, and the validation score comes out optimistic.

For a model whose whole job is geographic generalisation, that inflation matters: it is the number used for early stopping and best-checkpoint selection. `block` mode holds out whole regions instead of scattered points, so no validation block touches a training block, and the score reflects generalisation to unseen geography rather than interpolation between neighbours.

## How

Each sample's coordinate is mapped to a coarse H3 cell (`h3.latlng_to_cell(lat, lon, block_h3_res)`), and whole cells are partitioned into train/val. Block size is tunable: res 3 is roughly 120 km across.

Verified:

- New unit tests (`tests/test_split.py`): block disjointness (no shared block between train and val), input/target alignment, the leak contrast versus `location` mode on clustered data, and `location` back-compat.
- On the real training set: 287,525 cells map to 41,162 res-3 blocks, an exact 90/10 split, and zero shared blocks between train and val.
- On a controlled retrain, the honest split lowered GeoScore from 0.508 (`location`) to 0.480 (`block`). That drop is the inflation being removed, not a regression; the model and recipe were identical.

One honest caveat worth flagging for reviewers: because `block` mode holds out whole regions, a species with a very small range can end up with all of its blocks on the training side and none in validation. On my data, 11 narrow-range watchlist endemics (Hawaii, New Zealand, Galapagos, Kagu) had zero validation samples under `block`, which shrinks the per-watchlist-species component of the GeoScore. It is the right tradeoff for an honest spatial estimate, but a stratified variant that guarantees each watchlist species keeps blocks on both sides would be a reasonable follow-up. Keeping this opt-in (default `location`) means nobody is surprised by it.

AI assistance (Claude) was used to implement the split, write the tests, and run the comparison.

Related: #17 (this split is how I measured the bat work honestly rather than on an inflated score).
