### PR TITLE
Add Aves protection feature to training and autotuning processes

### DIFF
--- a/docs/model/training.md
+++ b/docs/model/training.md
@@ -89,6 +89,7 @@ The training script handles the full pipeline automatically:
 | `--propagate_water_threshold` | `0.5` | `water_fraction` at or above which a cell counts as "high water" for the pure-ocean guard (0 = disabled) |
 | `--propagate_ocean_buffer_km` | `100` | A cell is "pure ocean" only if high-water *and* farther than this from the nearest land cell; terrestrial/coastal labels never propagate into one (0 = disabled) |
 | `--smooth_gaps` | `0` | Fill bounded temporal gaps up to N missing weeks after propagation (0..48; 0 = disabled; try 2) |
+| `--protect_aves_regions` | off | Preserve raw Aves presence/absence labels during propagation and gap smoothing in `europe`, `na_west_coast`, and/or `na_east_coast` |
 
 ### Learning Rate Schedule
 

--- a/model/autotune.py
+++ b/model/autotune.py
@@ -14,7 +14,8 @@ import torch
 from model.model import create_model
 from model.loss import MultiTaskLoss
 from utils.data import H3DataLoader, H3DataPreprocessor, create_dataloaders, load_ubiquitous_species
-from utils.taxonomy import TaxonomyManager
+from utils.regions import build_region_mask
+from utils.taxonomy import TaxonomyManager, find_taxonomy_csv
 
 
 TUNABLE_PARAMS = [
@@ -197,6 +198,8 @@ def run_autotune(
 
     # Raw data references for per-trial re-propagation (set in fresh-load path).
     _raw_lats = _raw_lons = _raw_weeks = _raw_species_lists = _raw_env = None
+    _protected_target_mask = None
+    _protected_aves = None
 
     cache_path = data_cache_path_fn(args)
     # Skip cache when tuning propagation params — cached data has fixed propagation.
@@ -253,6 +256,21 @@ def run_autotune(
             samples_per_cell,
         )
 
+        if getattr(args, 'protect_aves_regions', None):
+            taxonomy_path = Path(args.taxonomy) if args.taxonomy else find_taxonomy_csv()
+            if taxonomy_path is None or not taxonomy_path.exists():
+                raise ValueError('--protect_aves_regions requires a taxonomy CSV')
+            taxonomy = TaxonomyManager(taxonomy_path, remap_path='')
+            _protected_aves = {
+                meta['species_code'] for meta in taxonomy.code_to_meta.values()
+                if str(meta.get('class_name', '')).lower() == 'aves'
+            }
+            _protected_target_mask = build_region_mask(
+                lats, lons, args.protect_aves_regions)
+            print(f"   Protected raw Aves labels: {len(_protected_aves):,} species in "
+                  f"{_protected_target_mask.sum():,}/{len(lats):,} samples "
+                  f"({', '.join(args.protect_aves_regions)})")
+
         del loader
         gc.collect()
 
@@ -288,6 +306,8 @@ def run_autotune(
                 ocean_buffer_km=args.propagate_ocean_buffer_km,
                 smooth_gaps=args.smooth_gaps,
                 sample_cell_indices=sample_cell_indices,
+                protected_target_mask=_protected_target_mask,
+                protected_species=_protected_aves,
             )
 
         print("3. Preprocessing...")
@@ -505,6 +525,8 @@ def run_autotune(
                 ocean_buffer_km=float(p.get('propagate_ocean_buffer_km', args.propagate_ocean_buffer_km)),
                 smooth_gaps=int(p.get('smooth_gaps', args.smooth_gaps)),
                 sample_cell_indices=sample_cell_indices,
+                protected_target_mask=_protected_target_mask,
+                protected_species=_protected_aves,
             )
             _trial_pp = H3DataPreprocessor()
             _trial_inputs, _trial_targets = _trial_pp.prepare_training_data(

--- a/tests/test_aves_protection.py
+++ b/tests/test_aves_protection.py
@@ -1,0 +1,51 @@
+import numpy as np
+import pandas as pd
+
+from utils.data import H3DataPreprocessor
+from utils.regions import build_region_mask
+
+
+def test_propagation_preserves_protected_species_only_in_protected_targets():
+    lats = np.array([50.0, 50.1, 50.2])
+    lons = np.array([10.0, 10.1, 10.2])
+    weeks = np.array([1, 1, 1])
+    labels = [['bird', 'mammal'], [], []]
+    env = pd.DataFrame({'temperature_c': [10.0, 10.0, 10.0]})
+
+    result = H3DataPreprocessor.propagate_env_labels(
+        lats, lons, weeks, labels, env,
+        k=1, min_obs_threshold=2, max_radius_km=1000,
+        max_spread_factor=0, env_dist_max=0,
+        water_threshold=0, ocean_buffer_km=0,
+        protected_target_mask=np.array([False, True, False]),
+        protected_species={'bird'},
+    )
+
+    assert set(result[1]) == {'mammal'}
+    assert set(result[2]) == {'bird', 'mammal'}
+    assert labels == [['bird', 'mammal'], [], []]
+
+
+def test_gap_smoothing_preserves_protected_species():
+    labels = [['bird'], [], ['bird']]
+    added = H3DataPreprocessor.smooth_temporal_gaps(
+        np.array([50.0, 50.0, 50.0]),
+        np.array([10.0, 10.0, 10.0]),
+        np.array([1, 2, 3]),
+        labels,
+        max_gap=1,
+        protected_target_mask=np.array([True, True, True]),
+        protected_species={'bird'},
+    )
+
+    assert added == 0
+    assert labels == [['bird'], [], ['bird']]
+
+
+def test_default_regions_leave_great_plains_unprotected():
+    lats = np.array([51.0, 40.0, 40.0, 40.0])
+    lons = np.array([10.0, -120.0, -100.0, -75.0])
+    mask = build_region_mask(
+        lats, lons, ['europe', 'na_west_coast', 'na_east_coast'])
+
+    assert mask.tolist() == [True, True, False, True]

--- a/train.py
+++ b/train.py
@@ -42,8 +42,9 @@ from model.loss import MultiTaskLoss
 from model.metrics import compute_geoscore
 from model.autotune import TUNABLE_PARAMS, run_autotune
 from utils.data import H3DataLoader, H3DataPreprocessor, create_dataloaders, load_ubiquitous_species
-from utils.regions import HOLDOUT_REGIONS, resolve_holdout_regions, REGION_BOUNDS
-from utils.taxonomy import TaxonomyManager
+from utils.regions import (AVES_PROTECTION_REGIONS, HOLDOUT_REGIONS, REGION_BOUNDS,
+                           build_region_mask, resolve_holdout_regions)
+from utils.taxonomy import TaxonomyManager, find_taxonomy_csv
 
 
 # ---------------------------------------------------------------------------
@@ -59,6 +60,7 @@ _DATA_CACHE_KEYS = [
     'propagate_labels', 'propagate_k', 'propagate_max_radius',
     'propagate_min_obs', 'propagate_max_spread',
     'propagate_env_dist_max', 'propagate_range_cap', 'smooth_gaps',
+    'protect_aves_regions',
     'max_obs_per_species', 'min_obs_per_species', 'max_species',
     'val_size', 'sample_fraction',
     'holdout_regions',
@@ -1023,6 +1025,11 @@ def main():
                         help='Fill bounded temporal gaps up to N missing weeks after '
                              'label propagation (0..48). 0 = disabled; try 2 for GIF-like '
                              'range smoothing (default: 0).')
+    parser.add_argument('--protect_aves_regions', nargs='+',
+                        choices=sorted(AVES_PROTECTION_REGIONS), default=None,
+                        help='Keep raw Aves labels immutable during propagation and gap '
+                             'smoothing in these well-observed regions. Available: '
+                             f"{', '.join(sorted(AVES_PROTECTION_REGIONS))}")
 
     # LR schedule
     parser.add_argument('--lr_schedule', type=str, default='cosine', choices=['cosine', 'none'],
@@ -1229,6 +1236,22 @@ def main():
                 np.arange(len(species_lists) // samples_per_cell),
                 samples_per_cell,
             )
+            protected_target_mask = None
+            protected_aves = None
+            if args.protect_aves_regions:
+                taxonomy_path = Path(args.taxonomy) if args.taxonomy else find_taxonomy_csv()
+                if taxonomy_path is None or not taxonomy_path.exists():
+                    raise ValueError('--protect_aves_regions requires a taxonomy CSV')
+                taxonomy = TaxonomyManager(taxonomy_path, remap_path='')
+                protected_aves = {
+                    meta['species_code'] for meta in taxonomy.code_to_meta.values()
+                    if str(meta.get('class_name', '')).lower() == 'aves'
+                }
+                protected_target_mask = build_region_mask(
+                    lats, lons, args.protect_aves_regions)
+                print(f"   Protected raw Aves labels: {len(protected_aves):,} species in "
+                      f"{protected_target_mask.sum():,}/{len(lats):,} samples "
+                      f"({', '.join(args.protect_aves_regions)})")
             
             species_lists = H3DataPreprocessor.propagate_env_labels(
                 lats, lons, weeks, species_lists, env_features,
@@ -1242,6 +1265,8 @@ def main():
                 ocean_buffer_km=args.propagate_ocean_buffer_km,
                 smooth_gaps=args.smooth_gaps,
                 sample_cell_indices=sample_cell_indices,
+                protected_target_mask=protected_target_mask,
+                protected_species=protected_aves,
             )
 
         print("3. Preprocessing...")

--- a/utils/data.py
+++ b/utils/data.py
@@ -223,6 +223,8 @@ class H3DataPreprocessor:
         max_gap: int,
         sample_cell_indices: Optional[np.ndarray] = None,
         candidate_species: Optional[Set[str]] = None,
+        protected_target_mask: Optional[np.ndarray] = None,
+        protected_species: Optional[Set[str]] = None,
     ) -> int:
         """Fill bounded weekly gaps in per-cell species presence series.
 
@@ -264,6 +266,11 @@ class H3DataPreprocessor:
                 raise ValueError("sample_cell_indices must match species_lists length")
 
         candidate_species = set(candidate_species) if candidate_species is not None else None
+        protected_species = set(protected_species or ())
+        if protected_target_mask is not None:
+            protected_target_mask = np.asarray(protected_target_mask, dtype=bool)
+            if len(protected_target_mask) != len(species_lists):
+                raise ValueError("protected_target_mask must match species_lists length")
         week_order = list(range(1, 49))
         week_to_pos = {week: pos for pos, week in enumerate(week_order)}
         n_weeks = len(week_order)
@@ -300,6 +307,10 @@ class H3DataPreprocessor:
                         week = week_order[pos % n_weeks]
                         sample_idx = week_to_sample.get(week)
                         if sample_idx is None:
+                            continue
+                        if (protected_target_mask is not None
+                                and protected_target_mask[sample_idx]
+                                and species_id in protected_species):
                             continue
                         species_list = species_lists[sample_idx]
                         if species_id not in species_list:
@@ -618,6 +629,8 @@ class H3DataPreprocessor:
         env_row_indices: Optional[np.ndarray] = None,
         smooth_gaps: int = 0,
         sample_cell_indices: Optional[np.ndarray] = None,
+        protected_target_mask: Optional[np.ndarray] = None,
+        protected_species: Optional[Set[str]] = None,
     ) -> List[List[str]]:
         """Propagate species labels from observed to sparse/unobserved cells.
 
@@ -688,6 +701,11 @@ class H3DataPreprocessor:
             sample_cell_indices: Optional per-sample cell ids for temporal gap
                 smoothing. If omitted and smoothing is enabled, samples are
                 grouped by exact latitude/longitude.
+            protected_target_mask: Optional boolean per-sample mask. Synthetic
+                labels in ``protected_species`` are not added to masked target
+                samples by either spatial propagation or temporal smoothing.
+            protected_species: Species codes whose raw presence/absence labels
+                are immutable in protected target samples.
 
         Returns:
             A new list-of-lists with propagated labels.  The caller's
@@ -707,6 +725,11 @@ class H3DataPreprocessor:
         # structure first, which is expensive at multi-million-row scale.
         species_lists = list(species_lists)
         n = len(species_lists)
+        protected_species = set(protected_species or ())
+        if protected_target_mask is not None:
+            protected_target_mask = np.asarray(protected_target_mask, dtype=bool)
+            if len(protected_target_mask) != n:
+                raise ValueError("protected_target_mask must match species_lists length")
 
         # Identify observed vs sparse samples
         obs_counts = np.array([len(sl) for sl in species_lists], dtype=np.int32)
@@ -720,6 +743,8 @@ class H3DataPreprocessor:
                 lats, lons, weeks, species_lists, smooth_gaps,
                 sample_cell_indices=sample_cell_indices,
                 candidate_species=candidate_species,
+                protected_target_mask=protected_target_mask,
+                protected_species=protected_species,
             )
             print(f"   Env label propagation: nothing to propagate "
                   f"({n_observed:,} observed, {n_sparse:,} sparse)")
@@ -998,6 +1023,24 @@ class H3DataPreprocessor:
             if len(cand_rows) == 0:
                 continue
 
+            # Preserve raw presence/absence labels for selected taxa in
+            # trusted target regions. Protected observations may still act as
+            # donors, and other taxa may still be propagated into these cells.
+            if protected_target_mask is not None and protected_species:
+                protected_cols = np.fromiter(
+                    (sp in protected_species for sp in sp_list),
+                    dtype=bool, count=n_sp,
+                )
+                keep = ~(
+                    protected_target_mask[sparse_in[cand_rows]]
+                    & protected_cols[cand_cols]
+                )
+                cand_rows = cand_rows[keep]
+                cand_cols = cand_cols[keep]
+
+            if len(cand_rows) == 0:
+                continue
+
             # Range filter: distance to nearest original observation
             if max_spread_factor > 0 and sp_trees:
                 t_lat_r = np.radians(lats[sparse_in[cand_rows]])
@@ -1068,6 +1111,8 @@ class H3DataPreprocessor:
             lats, lons, weeks, species_lists, smooth_gaps,
             sample_cell_indices=sample_cell_indices,
             candidate_species=candidate_species,
+            protected_target_mask=protected_target_mask,
+            protected_species=protected_species,
         )
         if temporal_added > 0:
             print(f"   Temporal gap smoothing: added {temporal_added:,} labels "
@@ -2140,4 +2185,3 @@ def load_ubiquitous_species(path: str) -> List[Tuple[str, float]]:
                 f"{path}:{lineno}: probability {prob} outside [0, 1]")
         out.append((code, prob))
     return out
-

--- a/utils/regions.py
+++ b/utils/regions.py
@@ -6,6 +6,8 @@ a region name) into a (lon_min, lat_min, lon_max, lat_max) tuple.
 """
 from typing import Dict, List, Optional, Sequence, Tuple
 
+import numpy as np
+
 # Region bounding boxes (lon_min, lat_min, lon_max, lat_max)
 REGION_BOUNDS = {
     'world': (-180.0, -90.0, 180.0, 90.0),
@@ -74,6 +76,32 @@ HOLDOUT_REGIONS: Dict[str, Tuple[float, float, float, float]] = {
     'california':   (-124.5, 32.5, -114.1, 42.0),     # California
     'japan':        (129.5, 30.0, 145.8, 45.5),        # Japan
 }
+
+# Areas where aggregated bird observations are dense enough that callers may
+# choose to preserve raw Aves absences during pseudo-label generation.  The
+# North American presets deliberately leave the continental interior
+# (-114..-90 degrees longitude) unprotected.
+AVES_PROTECTION_REGIONS: Dict[str, List[Tuple[float, float, float, float]]] = {
+    'europe': [REGION_BOUNDS['europe']],
+    'na_west_coast': [(-170.0, 25.0, -114.0, 72.0)],
+    'na_east_coast': [(-90.0, 25.0, -50.0, 72.0)],
+}
+
+
+def build_region_mask(
+    lats: np.ndarray,
+    lons: np.ndarray,
+    region_names: Optional[Sequence[str]],
+) -> np.ndarray:
+    """Return a sample mask for named Aves-protection regions."""
+    mask = np.zeros(len(lats), dtype=bool)
+    for name in region_names or []:
+        for lon_min, lat_min, lon_max, lat_max in AVES_PROTECTION_REGIONS[name]:
+            mask |= (
+                (lats >= lat_min) & (lats <= lat_max)
+                & (lons >= lon_min) & (lons <= lon_max)
+            )
+    return mask
 
 
 def resolve_bounds_arg(b: Optional[Sequence[str]]) -> Optional[Tuple[float, float, float, float]]:


### PR DESCRIPTION
Introduce a feature to preserve raw Aves presence/absence labels during propagation and gap smoothing in specified regions. This enhancement includes updates to the training and autotuning processes, allowing users to specify regions where Aves labels should remain immutable. Tests ensure that protected species are preserved as intended.